### PR TITLE
fix panic: interface conversion: interface {} is nil, not []interface {}

### DIFF
--- a/bitstamp.go
+++ b/bitstamp.go
@@ -136,8 +136,14 @@ func (api *Api) parseOrderBook(data []byte) (*OrderBook, error) {
 
 	result := &OrderBook{Time: time.Unix(timestamp, 0)}
 
-	bids := defaultstruct["bids"].([]interface{})
-	asks := defaultstruct["asks"].([]interface{})
+	bids, ok := defaultstruct["bids"].([]interface{})
+	if !ok {
+		return nil, errors.Wrap(err, "bids interface convert error")
+	}
+	asks, ok := defaultstruct["asks"].([]interface{})
+	if !ok {
+		return nil, errors.Wrap(err, "asks interface convert error")
+	}
 
 	parse := func(arr []interface{}) ([]Order, error) {
 		var result []Order
@@ -174,6 +180,9 @@ func (api *Api) parseOrderBook(data []byte) (*OrderBook, error) {
 // GetTrades returns the list of last trades with default parameters.
 func (api *Api) GetTrades(symbol string) (trades []Trade, err error) {
 	body, err := api.get("/transactions/" + symbol)
+	if err != nil {
+		return nil, errors.Wrap(err, "get transactions error")
+	}
 	return formatTrades(body)
 }
 

--- a/bitstamp_test.go
+++ b/bitstamp_test.go
@@ -24,7 +24,7 @@ func TestTicker(t *testing.T) {
 	api := Init()
 	ticker, err := api.GetTicker("btcusd")
 	if err != nil {
-		t.Errorf("Could not fetch ticker :", err)
+		t.Errorf("Could not fetch ticker : %s", err)
 	}
 	if ticker.Last == 0 {
 		t.Errorf("Ticker probably wrongly filled")
@@ -35,7 +35,7 @@ func TestOrderBook(t *testing.T) {
 	api := Init()
 	orderbook, err := api.GetOrderBook("btcusd")
 	if err != nil {
-		t.Errorf("Could not fetch orderbook :", err)
+		t.Errorf("Could not fetch orderbook : %s", err)
 	}
 	if orderbook.Asks[0].Price == 0. {
 		t.Errorf("Orderbook probably wrongly filled")
@@ -46,7 +46,7 @@ func TestTrades(t *testing.T) {
 	api := Init()
 	trades, err := api.GetTrades("btcusd")
 	if err != nil {
-		t.Errorf("Could not fetch trades :", err)
+		t.Errorf("Could not fetch trades : %s", err)
 	}
 	if len(trades) == 0 || trades[0].Price == 0. {
 		t.Errorf("trades probably wrongly filled")
@@ -57,7 +57,7 @@ func TestTradesParams(t *testing.T) {
 	api := Init()
 	trades, err := api.GetTradesParams("btcusd", "")
 	if err != nil {
-		t.Errorf("Could not fetch trades with params:", err)
+		t.Errorf("Could not fetch trades with params: %s", err)
 	}
 	if len(trades) == 0 || trades[0].Price == 0. {
 		t.Errorf("trades with params probably wrongly filled")


### PR DESCRIPTION
HI! We have panic errors sometimes: 

> panic: interface conversion: interface {} is nil, not []interface {}

This MR fix this errors, plz approve and merge it.